### PR TITLE
Place skip_on_rain at end of GardenSchedule to match SQLite column order

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -48,3 +48,15 @@ SUMP_PUMP_MAX_RUNTIME=60 # seconds
 
 TELEMETRY_API_KEY="api-key"
 TELEMETRY_RECEIVER_URL="https://api.honeycomb.io:443"
+
+# Precipitation-aware skip (Open-Meteo). When disabled, schedules never skip
+# for rain — set WEATHER_ENABLED=true and supply lat/lon to turn the feature on.
+WEATHER_ENABLED=false
+# WEATHER_LATITUDE=40.7128
+# WEATHER_LONGITUDE=-74.0060
+# WEATHER_PAST_HOURS=24
+# WEATHER_FORECAST_HOURS=12
+# WEATHER_THRESHOLD_MM=5.0
+# WEATHER_FORECAST_WEIGHT=0.5
+# WEATHER_ACTIVE_RAIN_MM=0.3
+# WEATHER_CACHE_TTL_SECS=900

--- a/README.md
+++ b/README.md
@@ -36,6 +36,57 @@ Group of inputs/callback handlers and outputs that form the sump pump functional
 
 ![Sump pump diagram](./assets/rp_sump.png)
 
+## Precipitation-aware garden schedules
+
+When the weather feature is enabled, the garden scheduler will skip a
+scheduled run if it has rained recently, is currently raining, or is forecast
+to rain soon. Schedules can opt out individually (e.g. for covered or indoor
+zones) by setting `skip_on_rain = false` on the schedule (the default for
+new schedules is `true`). When a run is skipped, a `GardenEvent` row is
+written with status `skipped` instead of `queued`, so the event history
+reflects why nothing ran.
+
+### How the skip decision works
+
+For every scheduler tick, the system fetches an hourly precipitation reading
+from [Open-Meteo](https://open-meteo.com/) (`past_hours` of observations
+plus `forecast_hours` of forecast in one request) and builds a snapshot:
+
+- `past_mm` — total observed precipitation over the last `past_hours` hours
+- `current_mm` — precipitation for the in-progress hour (used as an
+  actively-raining sensor)
+- `forecast_mm` — total forecast precipitation over the next `forecast_hours`
+  hours after the current hour
+
+A schedule's run is skipped when:
+
+1. The snapshot is available, and the schedule has `skip_on_rain = true`, and
+2. **either** `current_mm >= active_rain_mm` (it's actively raining)
+3. **or** `past_mm + forecast_weight * forecast_mm >= threshold_mm`
+
+The forecast is intentionally discounted by `forecast_weight` (default
+`0.5`) since observations are more reliable than predictions. If the
+Open-Meteo request fails or the feature is disabled, the snapshot is marked
+unavailable and no schedules are skipped — better to over-water than to dry
+out a bed because an API was down.
+
+### Config knobs
+
+| Knob               | Default | Meaning                                               |
+|--------------------|---------|-------------------------------------------------------|
+| `WEATHER_ENABLED`  | `false` | Master switch; when off, nothing is ever skipped      |
+| `WEATHER_LATITUDE` / `WEATHER_LONGITUDE` | —    | Location used for the Open-Meteo query           |
+| `WEATHER_PAST_HOURS`     | `24`    | Hours of observed precipitation to total              |
+| `WEATHER_FORECAST_HOURS` | `12`    | Hours of forecast to total (after the current hour)   |
+| `WEATHER_THRESHOLD_MM`   | `5.0`   | Composite skip threshold for past + weighted forecast |
+| `WEATHER_FORECAST_WEIGHT`| `0.5`   | Discount applied to forecast vs. observed             |
+| `WEATHER_ACTIVE_RAIN_MM` | `0.3`   | Current-hour mm above which "it is raining now"       |
+| `WEATHER_CACHE_TTL_SECS` | `900`   | How long to reuse a snapshot between scheduler ticks  |
+
+`skip_on_rain` is a per-schedule boolean column on `garden_schedule`
+(defaults to `true` for new schedules), so multi-zone gardens can mix
+uncovered beds with rain-immune zones.
+
 ## Hardware
 
 ##### Raspberry Pi

--- a/migrations/2026-05-23-000000_add_skip_on_rain_to_garden_schedule/down.sql
+++ b/migrations/2026-05-23-000000_add_skip_on_rain_to_garden_schedule/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "garden_schedule" DROP COLUMN "skip_on_rain";

--- a/migrations/2026-05-23-000000_add_skip_on_rain_to_garden_schedule/up.sql
+++ b/migrations/2026-05-23-000000_add_skip_on_rain_to_garden_schedule/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "garden_schedule"
+  ADD COLUMN "skip_on_rain" BOOLEAN NOT NULL DEFAULT 1;

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,8 @@ use dotenv::dotenv;
 use serde::Deserialize;
 use std::env;
 
+use crate::hydro::weather::WeatherConfig;
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct Settings {
     pub console: ConsoleConfig,
@@ -29,6 +31,7 @@ pub struct HydroConfig {
     pub heater: HeaterConfig,
     pub pool_pump: PoolPumpConfig,
     pub sump: SumpConfig,
+    pub weather: WeatherConfig,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -121,6 +124,7 @@ impl Settings {
                         .expect("POOL_PUMP_MAX_PIN must be a number."),
                 },
                 sump: Self::sump_config().expect("Could not load sump config."),
+                weather: Self::weather_config(),
             },
             jwt_secret,
             mailer: MailerConfig {
@@ -171,6 +175,53 @@ impl Settings {
             process_frequency_sec,
             max_seconds_runtime,
         })
+    }
+
+    fn weather_config() -> WeatherConfig {
+        // If WEATHER_ENABLED is unset or false, fall back to a fully-defaulted
+        // disabled config — no other env vars are required for that case.
+        let enabled = env::var("WEATHER_ENABLED")
+            .ok()
+            .and_then(|v| v.parse::<bool>().ok())
+            .unwrap_or(false);
+
+        if !enabled {
+            return WeatherConfig::disabled();
+        }
+
+        WeatherConfig {
+            enabled: true,
+            latitude: load_system_var("WEATHER_LATITUDE")
+                .parse()
+                .expect("WEATHER_LATITUDE must be a number."),
+            longitude: load_system_var("WEATHER_LONGITUDE")
+                .parse()
+                .expect("WEATHER_LONGITUDE must be a number."),
+            past_hours: env::var("WEATHER_PAST_HOURS")
+                .unwrap_or_else(|_| "24".to_string())
+                .parse()
+                .expect("WEATHER_PAST_HOURS must be a number."),
+            forecast_hours: env::var("WEATHER_FORECAST_HOURS")
+                .unwrap_or_else(|_| "12".to_string())
+                .parse()
+                .expect("WEATHER_FORECAST_HOURS must be a number."),
+            threshold_mm: env::var("WEATHER_THRESHOLD_MM")
+                .unwrap_or_else(|_| "5.0".to_string())
+                .parse()
+                .expect("WEATHER_THRESHOLD_MM must be a number."),
+            forecast_weight: env::var("WEATHER_FORECAST_WEIGHT")
+                .unwrap_or_else(|_| "0.5".to_string())
+                .parse()
+                .expect("WEATHER_FORECAST_WEIGHT must be a number."),
+            active_rain_mm: env::var("WEATHER_ACTIVE_RAIN_MM")
+                .unwrap_or_else(|_| "0.3".to_string())
+                .parse()
+                .expect("WEATHER_ACTIVE_RAIN_MM must be a number."),
+            cache_ttl_secs: env::var("WEATHER_CACHE_TTL_SECS")
+                .unwrap_or_else(|_| "900".to_string())
+                .parse()
+                .expect("WEATHER_CACHE_TTL_SECS must be a number."),
+        }
     }
 
     fn sump_config() -> Option<SumpConfig> {

--- a/src/hydro/garden/schedule.rs
+++ b/src/hydro/garden/schedule.rs
@@ -3,6 +3,7 @@ use tokio::task::JoinHandle;
 use tokio::time::{sleep, Duration};
 
 use crate::hydro::garden::Garden;
+use crate::hydro::weather::WeatherClient;
 use crate::repository::models::{
     garden_event::{GardenEvent, GardenEventStatus},
     garden_schedule::GardenSchedule,
@@ -11,12 +12,18 @@ use crate::repository::Repo;
 
 /// Spawned at startup. Each tick: queue any newly-due events, then drive the
 /// next queued event to completion before sleeping again.
-pub fn start(repo: Repo, garden: Garden, frequency_sec: u64) -> JoinHandle<()> {
+pub fn start(
+    repo: Repo,
+    garden: Garden,
+    weather: WeatherClient,
+    frequency_sec: u64,
+) -> JoinHandle<()> {
     tokio::spawn(async move {
         loop {
             let now = Utc::now().naive_utc();
+            let precip = weather.snapshot().await;
 
-            if let Err(e) = repo.queue_due_garden_events(now).await {
+            if let Err(e) = repo.queue_due_garden_events(now, &precip).await {
                 tracing::error!("garden: failed to queue due events: {}", e);
             }
 

--- a/src/hydro/mod.rs
+++ b/src/hydro/mod.rs
@@ -6,7 +6,10 @@ use tokio::{
 
 use crate::{
     config::HydroConfig,
-    hydro::{garden::Garden, gpio::Gpio, heater::Heater, pool_pump::PoolPump, sump::Sump},
+    hydro::{
+        garden::Garden, gpio::Gpio, heater::Heater, pool_pump::PoolPump, sump::Sump,
+        weather::WeatherClient,
+    },
     repository::Repo,
 };
 
@@ -21,6 +24,7 @@ pub mod pool_pump;
 pub mod sensor;
 pub mod signal;
 mod sump;
+pub mod weather;
 
 // Re-exports so siblings can reference `crate::hydro::Control` / `crate::hydro::Level`
 // (matches the convention from prior to the garden refactor).
@@ -51,8 +55,14 @@ impl Hydro {
 
         let sump = Sump::new(&config.sump, &tx, handle.clone(), gpio)?;
         let garden = Garden::new(&config.garden, gpio)?;
+        let weather = WeatherClient::new(config.weather.clone());
 
-        garden::schedule::start(repo, garden.clone(), config.garden.process_frequency_sec);
+        garden::schedule::start(
+            repo,
+            garden.clone(),
+            weather,
+            config.garden.process_frequency_sec,
+        );
 
         signal::listen(
             mpsc.1,

--- a/src/hydro/weather.rs
+++ b/src/hydro/weather.rs
@@ -1,0 +1,334 @@
+//! Precipitation-aware skip decisions for garden schedules.
+//!
+//! The skip logic is intentionally a pure function over a [`PrecipSnapshot`].
+//! HTTP fetching lives in [`WeatherClient`] and produces snapshots; tests
+//! construct snapshots directly without going through HTTP.
+//!
+//! Decision:
+//!   skip = available
+//!       AND schedule.skip_on_rain
+//!       AND (current_mm >= active_rain_mm
+//!            OR past_mm + forecast_weight * forecast_mm >= threshold_mm)
+//!
+//! If the snapshot is `available == false` (API down or feature disabled),
+//! we never skip — better a wasted watering than a parched bed.
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Error};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+use crate::repository::models::garden_schedule::GardenSchedule;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct WeatherConfig {
+    pub enabled: bool,
+    pub latitude: f32,
+    pub longitude: f32,
+    pub past_hours: u32,
+    pub forecast_hours: u32,
+    pub threshold_mm: f32,
+    pub forecast_weight: f32,
+    pub active_rain_mm: f32,
+    pub cache_ttl_secs: u64,
+}
+
+impl WeatherConfig {
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            latitude: 0.0,
+            longitude: 0.0,
+            past_hours: 24,
+            forecast_hours: 12,
+            threshold_mm: 5.0,
+            forecast_weight: 0.5,
+            active_rain_mm: 0.3,
+            cache_ttl_secs: 900,
+        }
+    }
+}
+
+/// A point-in-time view of precipitation that is enough to make a skip
+/// decision without further I/O. Constructed by `WeatherClient::snapshot`
+/// or directly in tests.
+#[derive(Clone, Copy, Debug)]
+pub struct PrecipSnapshot {
+    pub past_mm: f32,
+    pub forecast_mm: f32,
+    pub current_mm: f32,
+    pub threshold_mm: f32,
+    pub forecast_weight: f32,
+    pub active_rain_mm: f32,
+    pub available: bool,
+}
+
+impl PrecipSnapshot {
+    pub fn unavailable() -> Self {
+        Self {
+            past_mm: 0.0,
+            forecast_mm: 0.0,
+            current_mm: 0.0,
+            threshold_mm: 0.0,
+            forecast_weight: 0.0,
+            active_rain_mm: 0.0,
+            available: false,
+        }
+    }
+
+    pub fn effective_mm(&self) -> f32 {
+        self.past_mm + self.forecast_weight * self.forecast_mm
+    }
+
+    pub fn is_actively_raining(&self) -> bool {
+        self.current_mm >= self.active_rain_mm
+    }
+
+    pub fn is_wet(&self) -> bool {
+        if !self.available {
+            return false;
+        }
+        self.is_actively_raining() || self.effective_mm() >= self.threshold_mm
+    }
+}
+
+/// Pure: should this specific schedule be skipped right now, given a snapshot?
+/// Honors the per-schedule `skip_on_rain` flag so covered/indoor zones can opt out.
+pub fn should_skip(schedule: &GardenSchedule, precip: &PrecipSnapshot) -> bool {
+    schedule.skip_on_rain && precip.is_wet()
+}
+
+// --- HTTP client ----------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct CachedReading {
+    fetched_at: DateTime<Utc>,
+    past_mm: f32,
+    forecast_mm: f32,
+    current_mm: f32,
+}
+
+#[derive(Clone)]
+pub struct WeatherClient {
+    cfg: WeatherConfig,
+    http: reqwest::Client,
+    cache: Arc<RwLock<Option<CachedReading>>>,
+}
+
+#[derive(Deserialize)]
+struct OpenMeteoResponse {
+    hourly: OpenMeteoHourly,
+}
+
+#[derive(Deserialize)]
+struct OpenMeteoHourly {
+    precipitation: Vec<f32>,
+}
+
+impl WeatherClient {
+    pub fn new(cfg: WeatherConfig) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .expect("reqwest client");
+        Self {
+            cfg,
+            http,
+            cache: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    pub async fn snapshot(&self) -> PrecipSnapshot {
+        if !self.cfg.enabled {
+            return PrecipSnapshot::unavailable();
+        }
+        match self.reading().await {
+            Ok(r) => PrecipSnapshot {
+                past_mm: r.past_mm,
+                forecast_mm: r.forecast_mm,
+                current_mm: r.current_mm,
+                threshold_mm: self.cfg.threshold_mm,
+                forecast_weight: self.cfg.forecast_weight,
+                active_rain_mm: self.cfg.active_rain_mm,
+                available: true,
+            },
+            Err(e) => {
+                tracing::warn!("weather lookup failed, watering anyway: {e}");
+                PrecipSnapshot::unavailable()
+            }
+        }
+    }
+
+    async fn reading(&self) -> Result<CachedReading, Error> {
+        let ttl = Duration::seconds(self.cfg.cache_ttl_secs as i64);
+        if let Some(r) = self.cache.read().await.clone() {
+            if Utc::now() - r.fetched_at < ttl {
+                return Ok(r);
+            }
+        }
+        let r = self.fetch().await?;
+        *self.cache.write().await = Some(r.clone());
+        Ok(r)
+    }
+
+    async fn fetch(&self) -> Result<CachedReading, Error> {
+        let url = format!(
+            "https://api.open-meteo.com/v1/forecast\
+             ?latitude={lat}&longitude={lon}\
+             &hourly=precipitation\
+             &past_hours={past}&forecast_hours={fwd}\
+             &timezone=UTC",
+            lat = self.cfg.latitude,
+            lon = self.cfg.longitude,
+            past = self.cfg.past_hours,
+            fwd = self.cfg.forecast_hours,
+        );
+
+        let resp: OpenMeteoResponse = self.http.get(&url).send().await?.json().await?;
+        let past_n = self.cfg.past_hours as usize;
+        let values = resp.hourly.precipitation;
+
+        if values.len() < past_n + 1 {
+            return Err(anyhow!(
+                "open-meteo returned {} hours, expected at least {}",
+                values.len(),
+                past_n + 1
+            ));
+        }
+
+        // Layout (confirmed against api.open-meteo.com): [past..., current, forecast...]
+        // index 0..past_n      = past_hours observed/analyzed hours
+        // index past_n         = current (in-progress) hour
+        // index past_n+1..end  = forecast hours after the current hour
+        let past_mm: f32 = values[..past_n].iter().sum();
+        let current_mm: f32 = values[past_n];
+        let forecast_mm: f32 = values[past_n + 1..].iter().sum();
+
+        Ok(CachedReading {
+            fetched_at: Utc::now(),
+            past_mm,
+            forecast_mm,
+            current_mm,
+        })
+    }
+}
+
+// --- tests ---------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDateTime;
+
+    fn schedule(id: i32, skip_on_rain: bool) -> GardenSchedule {
+        GardenSchedule {
+            id,
+            name: format!("zone {id}"),
+            active: true,
+            start_times: "06:00".to_string(),
+            days_of_week: "Mon".to_string(),
+            duration_secs: 60,
+            skip_on_rain,
+            created_at: NaiveDateTime::default(),
+            updated_at: NaiveDateTime::default(),
+        }
+    }
+
+    fn snap(past: f32, current: f32, forecast: f32, available: bool) -> PrecipSnapshot {
+        PrecipSnapshot {
+            past_mm: past,
+            current_mm: current,
+            forecast_mm: forecast,
+            threshold_mm: 5.0,
+            forecast_weight: 0.5,
+            active_rain_mm: 0.3,
+            available,
+        }
+    }
+
+    #[test]
+    fn effective_mm_adds_weighted_forecast() {
+        let s = snap(2.0, 0.0, 4.0, true);
+        // 2.0 + 0.5 * 4.0 = 4.0
+        assert!((s.effective_mm() - 4.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn dry_snapshot_is_not_wet() {
+        assert!(!snap(0.0, 0.0, 0.0, true).is_wet());
+    }
+
+    #[test]
+    fn unavailable_snapshot_is_never_wet() {
+        // Big numbers but unavailable → still not wet.
+        let s = snap(100.0, 100.0, 100.0, false);
+        assert!(!s.is_wet());
+    }
+
+    #[test]
+    fn active_rain_short_circuits_threshold() {
+        // current_mm above active_rain_mm but effective_mm well under threshold.
+        let s = snap(0.0, 0.5, 0.0, true);
+        assert!(s.is_actively_raining());
+        assert!(s.effective_mm() < s.threshold_mm);
+        assert!(s.is_wet());
+    }
+
+    #[test]
+    fn drizzle_below_active_rain_floor_does_not_trip_active_check() {
+        let s = snap(0.0, 0.1, 0.0, true);
+        assert!(!s.is_actively_raining());
+        assert!(!s.is_wet());
+    }
+
+    #[test]
+    fn past_alone_can_meet_threshold() {
+        let s = snap(8.0, 0.0, 0.0, true);
+        assert!(s.is_wet());
+    }
+
+    #[test]
+    fn forecast_alone_must_exceed_threshold_after_weighting() {
+        // 9mm forecast * 0.5 weight = 4.5, under 5.0 threshold.
+        let under = snap(0.0, 0.0, 9.0, true);
+        assert!(!under.is_wet());
+
+        // 12mm forecast * 0.5 weight = 6.0, over threshold.
+        let over = snap(0.0, 0.0, 12.0, true);
+        assert!(over.is_wet());
+    }
+
+    #[test]
+    fn threshold_boundary_is_inclusive() {
+        let s = snap(5.0, 0.0, 0.0, true);
+        assert!(s.is_wet());
+    }
+
+    #[test]
+    fn should_skip_dry_runs_everything() {
+        let s = snap(0.0, 0.0, 0.0, true);
+        assert!(!should_skip(&schedule(1, true), &s));
+        assert!(!should_skip(&schedule(2, false), &s));
+    }
+
+    #[test]
+    fn should_skip_wet_skips_only_rain_aware_schedules() {
+        let s = snap(8.0, 0.0, 0.0, true);
+        assert!(should_skip(&schedule(1, true), &s));
+        assert!(!should_skip(&schedule(2, false), &s));
+    }
+
+    #[test]
+    fn should_skip_unavailable_never_skips() {
+        let s = snap(100.0, 100.0, 100.0, false);
+        assert!(!should_skip(&schedule(1, true), &s));
+    }
+
+    #[test]
+    fn should_skip_wet_but_schedule_opts_out_runs() {
+        let s = snap(20.0, 5.0, 20.0, true);
+        assert!(!should_skip(&schedule(42, false), &s));
+    }
+}

--- a/src/repository/implementation.rs
+++ b/src/repository/implementation.rs
@@ -238,6 +238,7 @@ impl Repository for Implementation {
                 start_times: times_to_csv(&params.start_times),
                 days_of_week: days_to_csv(&params.days_of_week),
                 duration_secs: params.duration_secs,
+                skip_on_rain: params.skip_on_rain,
             };
 
             diesel::insert_into(garden_schedule::table)
@@ -633,11 +634,15 @@ impl Repository for Implementation {
     async fn queue_due_garden_events(
         &self,
         now: chrono::NaiveDateTime,
+        precip: &PrecipSnapshot,
     ) -> Result<usize, Error> {
         let mut conn = self
             .pool
             .get()
             .map_err(|e| anyhow!("Database error: {:?}", e))?;
+
+        // Copy out of &PrecipSnapshot so the spawn_blocking closure can be 'static.
+        let precip = *precip;
 
         let inserted = spawn_blocking_with_tracing(move || {
             let schedules: Vec<GardenSchedule> = garden_schedule_dsl::garden_schedule
@@ -654,15 +659,32 @@ impl Repository for Implementation {
                 if !days.iter().any(|d| *d == today_weekday) {
                     continue;
                 }
+                let skip = crate::hydro::weather::should_skip(schedule, &precip);
+                let status = if skip {
+                    GardenEventStatus::Skipped
+                } else {
+                    GardenEventStatus::Queued
+                };
                 for time in schedule.parsed_start_times() {
                     let scheduled_for = today.and_time(time);
                     if scheduled_for > now {
                         continue;
                     }
+                    if skip {
+                        tracing::info!(
+                            schedule_id = schedule.id,
+                            name = %schedule.name,
+                            past_mm = precip.past_mm,
+                            forecast_mm = precip.forecast_mm,
+                            current_mm = precip.current_mm,
+                            threshold_mm = precip.threshold_mm,
+                            "garden: skipping due event for precipitation"
+                        );
+                    }
                     new_rows.push(NewGardenEvent {
                         schedule_id: Some(schedule.id),
                         source: GardenEventSource::Scheduled.to_string(),
-                        status: GardenEventStatus::Queued.to_string(),
+                        status: status.to_string(),
                         scheduled_for,
                         duration_secs: schedule.duration_secs,
                     });
@@ -850,6 +872,9 @@ impl Repository for Implementation {
                     if let Some(duration_secs) = params.duration_secs {
                         s.duration_secs = duration_secs;
                     }
+                    if let Some(skip_on_rain) = params.skip_on_rain {
+                        s.skip_on_rain = skip_on_rain;
+                    }
                     s.updated_at = Utc::now().naive_utc();
 
                     let updated = diesel::update(garden_schedule::table)
@@ -860,6 +885,7 @@ impl Repository for Implementation {
                             garden_schedule::start_times.eq(&s.start_times),
                             garden_schedule::days_of_week.eq(&s.days_of_week),
                             garden_schedule::duration_secs.eq(s.duration_secs),
+                            garden_schedule::skip_on_rain.eq(s.skip_on_rain),
                             garden_schedule::updated_at.eq(s.updated_at),
                         ))
                         .get_result::<GardenSchedule>(&mut conn)

--- a/src/repository/implementation.rs
+++ b/src/repository/implementation.rs
@@ -4,6 +4,7 @@ use chrono::{Datelike, NaiveDate, Utc, Weekday};
 
 use crate::auth::password::Password;
 use crate::auth::token::Token;
+use crate::hydro::weather::{should_skip, PrecipSnapshot};
 use crate::repository::models::{
     garden_event::{GardenEvent, GardenEventSource, GardenEventStatus, NewGardenEvent},
     garden_schedule::{
@@ -659,7 +660,7 @@ impl Repository for Implementation {
                 if !days.iter().any(|d| *d == today_weekday) {
                     continue;
                 }
-                let skip = crate::hydro::weather::should_skip(schedule, &precip);
+                let skip = should_skip(schedule, &precip);
                 let status = if skip {
                     GardenEventStatus::Skipped
                 } else {

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -18,6 +18,7 @@ use models::{
 };
 
 use crate::auth::{password::Password, token::Token};
+use crate::hydro::weather::PrecipSnapshot;
 use crate::repository::models::user::{UserFilter, UserUpdateFilter};
 
 use self::implementation::{RefreshTokenError, ResetPasswordError, VerifyEmailError};
@@ -79,7 +80,11 @@ pub trait Repository: Send + Sync + 'static {
     async fn garden_schedules(&self) -> Result<Vec<GardenSchedule>, Error>;
     async fn next_queued_garden_event(&self) -> Result<Option<GardenEvent>, Error>;
     async fn pool(&self) -> Result<Pool<ConnectionManager<SqliteConnection>>, Error>;
-    async fn queue_due_garden_events(&self, now: NaiveDateTime) -> Result<usize, Error>;
+    async fn queue_due_garden_events(
+        &self,
+        now: NaiveDateTime,
+        precip: &PrecipSnapshot,
+    ) -> Result<usize, Error>;
     async fn request_garden_stop(&self) -> Result<Option<i32>, Error>;
     async fn revoke_refresh_tokens_for_user(&self, user_id: i32) -> Result<(), Error>;
     async fn reset_password(

--- a/src/repository/models/garden_event.rs
+++ b/src/repository/models/garden_event.rs
@@ -13,6 +13,7 @@ pub enum GardenEventStatus {
     InProgress,
     Completed,
     Cancelled,
+    Skipped,
 }
 
 impl fmt::Display for GardenEventStatus {
@@ -22,6 +23,7 @@ impl fmt::Display for GardenEventStatus {
             GardenEventStatus::InProgress => write!(f, "in_progress"),
             GardenEventStatus::Completed => write!(f, "completed"),
             GardenEventStatus::Cancelled => write!(f, "cancelled"),
+            GardenEventStatus::Skipped => write!(f, "skipped"),
         }
     }
 }
@@ -35,6 +37,7 @@ impl FromStr for GardenEventStatus {
             "in_progress" => Ok(GardenEventStatus::InProgress),
             "completed" => Ok(GardenEventStatus::Completed),
             "cancelled" => Ok(GardenEventStatus::Cancelled),
+            "skipped" => Ok(GardenEventStatus::Skipped),
             other => Err(format!("unknown garden event status: {}", other)),
         }
     }

--- a/src/repository/models/garden_schedule.rs
+++ b/src/repository/models/garden_schedule.rs
@@ -26,9 +26,9 @@ pub struct GardenSchedule {
     )]
     pub days_of_week: String,
     pub duration_secs: i32,
-    pub skip_on_rain: bool,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
+    pub skip_on_rain: bool,
 }
 
 #[derive(Clone, Debug, Insertable)]

--- a/src/repository/models/garden_schedule.rs
+++ b/src/repository/models/garden_schedule.rs
@@ -26,6 +26,7 @@ pub struct GardenSchedule {
     )]
     pub days_of_week: String,
     pub duration_secs: i32,
+    pub skip_on_rain: bool,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
 }
@@ -38,6 +39,7 @@ pub struct NewGardenSchedule {
     pub start_times: String,
     pub days_of_week: String,
     pub duration_secs: i32,
+    pub skip_on_rain: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -48,6 +50,8 @@ pub struct CreateGardenScheduleParams {
     pub start_times: Vec<NaiveTime>,
     pub days_of_week: Vec<Weekday>,
     pub duration_secs: i32,
+    #[serde(default = "default_true")]
+    pub skip_on_rain: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -57,6 +61,7 @@ pub struct UpdateGardenScheduleParams {
     pub start_times: Option<Vec<NaiveTime>>,
     pub days_of_week: Option<Vec<Weekday>>,
     pub duration_secs: Option<i32>,
+    pub skip_on_rain: Option<bool>,
 }
 
 fn default_true() -> bool {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -19,6 +19,7 @@ diesel::table! {
         start_times -> Text,
         days_of_week -> Text,
         duration_secs -> Integer,
+        skip_on_rain -> Bool,
         created_at -> Timestamp,
         updated_at -> Timestamp,
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -19,9 +19,9 @@ diesel::table! {
         start_times -> Text,
         days_of_week -> Text,
         duration_secs -> Integer,
-        skip_on_rain -> Bool,
         created_at -> Timestamp,
         updated_at -> Timestamp,
+        skip_on_rain -> Bool,
     }
 }
 

--- a/tests/hydro/garden.rs
+++ b/tests/hydro/garden.rs
@@ -16,6 +16,7 @@ fn schedule(
         start_times: start_times.to_string(),
         days_of_week: days.to_string(),
         duration_secs,
+        skip_on_rain: true,
         created_at: NaiveDateTime::parse_from_str("2026-01-01 00:00:00", "%Y-%m-%d %H:%M:%S")
             .unwrap(),
         updated_at: NaiveDateTime::parse_from_str("2026-01-01 00:00:00", "%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
## Summary
Follow-up to #56. Running `diesel migration run` on a real SQLite DB causes diesel to regenerate `schema.rs` against the live table layout. `ALTER TABLE … ADD COLUMN skip_on_rain` appends the column to the end, so post-migration the column order is `(id, name, active, start_times, days_of_week, duration_secs, created_at, updated_at, skip_on_rain)` — but I placed `skip_on_rain` between `duration_secs` and `created_at` in both my hand-written `schema.rs` and the `GardenSchedule` struct.

The `Queryable` derive matches columns by positional order, so the build failed on the Pi after migration with:
```
the trait bound `(Integer, Text, Bool, Text, Text, Integer, Timestamp, Timestamp, Bool):
  CompatibleType<GardenSchedule, Sqlite>` is not satisfied
```

CI didn't catch this because the CI build doesn't run migrations against a real DB — it compiled against my repo `schema.rs` (where my ordering was internally consistent) and passed.

## Fix
Move `skip_on_rain` to the end in two places:
- `src/schema.rs` — `garden_schedule!` table macro
- `src/repository/models/garden_schedule.rs` — `GardenSchedule` struct field order

`NewGardenSchedule` (Insertable), `UpdateStatement::set(...)` (named columns), and all test fixtures use column-name-based or named-field syntax, so they're order-insensitive — no other changes needed.

## Test plan
- [ ] `make build` on the Pi (which runs `diesel migration run` first) — compiles.
- [ ] Existing `garden_schedule` rows still have `skip_on_rain = 1` (the migration default); confirm.
- [ ] One scheduler tick logs cleanly with `WEATHER_ENABLED=false` (no behavior change yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)