### PR TITLE
Place skip_on_rain at end of GardenSchedule to match SQLite column order

### DIFF
--- a/src/repository/models/garden_schedule.rs
+++ b/src/repository/models/garden_schedule.rs
@@ -26,9 +26,9 @@ pub struct GardenSchedule {
     )]
     pub days_of_week: String,
     pub duration_secs: i32,
-    pub skip_on_rain: bool,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
+    pub skip_on_rain: bool,
 }
 
 #[derive(Clone, Debug, Insertable)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -19,9 +19,9 @@ diesel::table! {
         start_times -> Text,
         days_of_week -> Text,
         duration_secs -> Integer,
-        skip_on_rain -> Bool,
         created_at -> Timestamp,
         updated_at -> Timestamp,
+        skip_on_rain -> Bool,
     }
 }
 


### PR DESCRIPTION
## Summary
Supersedes #57 (which had a stale base causing a 3-way-merge duplicate). Same single-commit fix, rebased onto current main.

`diesel migration run` regenerates `schema.rs` against the live SQLite table layout. Because the migration uses `ALTER TABLE ADD COLUMN skip_on_rain`, SQLite appends the column to the end of the row — so after the first migration, the canonical column order is `(…, duration_secs, created_at, updated_at, skip_on_rain)`. In #56 I placed `skip_on_rain` between `duration_secs` and `created_at` in both the hand-written `schema.rs` and the `GardenSchedule` struct, which builds fine until anyone runs `diesel migration run` locally — at which point the regenerated `schema.rs` no longer agrees with the struct's field order and `Queryable` fails:

```
the trait bound `(Integer, Text, Bool, Text, Text, Integer, Timestamp, Timestamp, Bool):
  CompatibleType<GardenSchedule, Sqlite>` is not satisfied
```

## Fix
Move `skip_on_rain` to the end of:
- `src/schema.rs` — `garden_schedule!` table macro
- `src/repository/models/garden_schedule.rs` — `GardenSchedule` struct

`NewGardenSchedule` (Insertable), `UpdateStatement::set(…)` (named columns), and all test fixtures use column-name-based or named-field syntax — order-insensitive, no other changes needed.

## Why #57 failed CI
PR #57 branched from the pre-squash commits of #56. After #56 was squash-merged into main, GitHub's 3-way merge for CI saw:
- merge base: no `skip_on_rain`
- main: `skip_on_rain` added in the middle (from the squash)
- PR branch: `skip_on_rain` removed from middle + added at end

Git treats main's middle addition and the branch's end addition as independent non-conflicting edits and includes both — duplicate definition. Rebasing onto current main resolves this; this PR is the rebased version.

## Test plan
- [ ] CI: `cargo test --features stub` passes (no duplicate definition errors).
- [ ] On the Pi: `make build` (which runs `diesel migration run` first) compiles cleanly.
- [ ] Existing `garden_schedule` rows continue to have `skip_on_rain = 1` (from the prior migration's default).

## Future-proofing
Adding a `diesel migration run` step to CI against an ephemeral SQLite would have caught both #56's column-order bug and the duplicate-after-rebase issue. Not in scope for this PR, but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)